### PR TITLE
make follower email optional on session creation

### DIFF
--- a/src/app/sessions/new/page.tsx
+++ b/src/app/sessions/new/page.tsx
@@ -117,6 +117,7 @@ export default function NewSessionPage() {
 
   const [saving, setSaving] = useState(false)
   const [error,  setError]  = useState('')
+  const [notifyFollowers, setNotifyFollowers] = useState(true)
 
   // Co-admin picker
   const [coAdmins,          setCoAdmins]          = useState<Profile[]>([])
@@ -208,11 +209,13 @@ export default function NewSessionPage() {
       }
 
       // Notify followers (fire-and-forget)
-      fetch('/api/notify-followers', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sessionId }),
-      }).catch(() => {})
+      if (notifyFollowers) {
+        fetch('/api/notify-followers', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sessionId }),
+        }).catch(() => {})
+      }
 
       dirtyRef.current = false  // clear guard before navigating
       router.push(`/sessions/${sessionId}`)
@@ -429,6 +432,16 @@ export default function NewSessionPage() {
             )}
           </div>
         </div>
+
+        <label className="flex items-center gap-2 px-1 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={notifyFollowers}
+            onChange={e => setNotifyFollowers(e.target.checked)}
+            className="w-4 h-4 rounded accent-brand-600"
+          />
+          <span className="text-sm text-gray-700">通知关注我的人</span>
+        </label>
 
         {error && (
           <p className="text-sm text-red-500 bg-red-50 rounded-xl px-4 py-3">{error}</p>


### PR DESCRIPTION
Adds a checkbox on the new-session form (default checked) that controls whether followers of the initiator receive the new-session email. When unchecked, the /api/notify-followers fetch is skipped.