### PR TITLE
fix cron 307 redirect: exclude /api/ from auth middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -49,5 +49,5 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)).*)'],
+  matcher: ['/((?!_next/static|_next/image|favicon.ico|api/|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)).*)'],
 }


### PR DESCRIPTION
API routes were being intercepted by the auth middleware and redirected to /login for unauthenticated requests. Excludes /api/ from the middleware matcher so cron-job.org and other server-to-server calls reach the endpoint directly.